### PR TITLE
Add LocalizationState to the ConqDataRecorder

### DIFF
--- a/scripts/generate_conq_hose_manipulation_dataset.py
+++ b/scripts/generate_conq_hose_manipulation_dataset.py
@@ -168,10 +168,8 @@ def main():
         command_client = setup_and_stand(robot)
 
         clients = Clients(lease=lease_client, state=robot_state_client, manipulation=manipulation_api_client,
-                          image=image_client, raycast=rc_client, command=command_client, robot=robot,
-                          recorder=None)
+                          image=image_client, raycast=rc_client, command=command_client, robot=robot)
         recorder = ConqDataRecorder(root, clients=clients)
-        clients.recorder = recorder
 
         open_gripper(clients)
         look_at_scene(clients, z=0.4, pitch=np.deg2rad(85))

--- a/scripts/generate_conq_hose_manipulation_dataset.py
+++ b/scripts/generate_conq_hose_manipulation_dataset.py
@@ -163,14 +163,15 @@ def main():
 
     now = int(time.time())
     root = Path(f"data/conq_hose_manipulation_data_{now}")
-    recorder = ConqDataRecorder(root, robot_state_client, image_client)
 
     with (LeaseKeepAlive(lease_client, must_acquire=True, return_at_exit=True)):
         command_client = setup_and_stand(robot)
 
         clients = Clients(lease=lease_client, state=robot_state_client, manipulation=manipulation_api_client,
                           image=image_client, raycast=rc_client, command=command_client, robot=robot,
-                          recorder=recorder)
+                          recorder=None)
+        recorder = ConqDataRecorder(root, clients=clients)
+        clients.recorder = recorder
 
         open_gripper(clients)
         look_at_scene(clients, z=0.4, pitch=np.deg2rad(85))

--- a/scripts/generate_data_from_vr.py
+++ b/scripts/generate_data_from_vr.py
@@ -76,7 +76,7 @@ class GenerateDataVRNode(Node):
 
         now = int(time.time())
         root = Path(f"data/conq_vr_data_{now}")
-        self.recorder = ConqDataRecorder(root, conq_clients.state, conq_clients.image,
+        self.recorder = ConqDataRecorder(root, conq_clients,
                                          sources=[
                                              'hand_color_image',
                                              'frontleft_fisheye_image',

--- a/src/conq/clients.py
+++ b/src/conq/clients.py
@@ -13,11 +13,11 @@ from bosdyn.client.graph_nav import GraphNavClient
 
 @dataclass
 class Clients:
-    lease: LeaseClient
-    state: RobotStateClient
-    manipulation: ManipulationApiClient
-    image: ImageClient
-    graphnav: GraphNavClient
-    raycast: RayCastClient
-    command: RobotCommandClient
-    robot: Robot
+    lease: Optional[LeaseClient]
+    state: Optional[RobotStateClient]
+    manipulation: Optional[ManipulationApiClient]
+    image: Optional[ImageClient]
+    graphnav: Optional[GraphNavClient]
+    raycast: Optional[RayCastClient]
+    command: Optional[RobotCommandClient]
+    robot: Optional[Robot]

--- a/src/conq/clients.py
+++ b/src/conq/clients.py
@@ -8,6 +8,7 @@ from bosdyn.client.ray_cast import RayCastClient
 from bosdyn.client.robot import Robot
 from bosdyn.client.robot_command import RobotCommandClient
 from bosdyn.client.robot_state import RobotStateClient
+from bosdyn.client.graph_nav import GraphNavClient
 
 from conq.data_recorder import ConqDataRecorder
 
@@ -18,6 +19,7 @@ class Clients:
     state: RobotStateClient
     manipulation: ManipulationApiClient
     image: ImageClient
+    graphnav: GraphNavClient
     raycast: RayCastClient
     command: RobotCommandClient
     robot: Robot

--- a/src/conq/clients.py
+++ b/src/conq/clients.py
@@ -10,8 +10,6 @@ from bosdyn.client.robot_command import RobotCommandClient
 from bosdyn.client.robot_state import RobotStateClient
 from bosdyn.client.graph_nav import GraphNavClient
 
-from conq.data_recorder import ConqDataRecorder
-
 
 @dataclass
 class Clients:
@@ -23,4 +21,3 @@ class Clients:
     raycast: RayCastClient
     command: RobotCommandClient
     robot: Robot
-    recorder: Optional[ConqDataRecorder] = None

--- a/src/conq/data_recorder.py
+++ b/src/conq/data_recorder.py
@@ -14,6 +14,8 @@ from bosdyn.client.image import build_image_request
 
 from conq.cameras_utils import RGB_SOURCES, DEPTH_SOURCES, ALL_SOURCES, source_to_fmt
 from conq.clients import Clients
+from conq.rerun_utils import viz_common_frames
+
 
 
 class ConqDataRecorder:
@@ -110,7 +112,6 @@ class ConqDataRecorder:
             # Check that the right cleint being requested is set before setting the step_data
             if clients.state is not None:
                 state = clients.state.get_robot_state()
-                from conq.rerun_utils import viz_common_frames
                 viz_common_frames(state.kinematic_state.transforms_snapshot)
                 step_data['robot_state'] = state
 

--- a/src/conq/data_recorder.py
+++ b/src/conq/data_recorder.py
@@ -93,31 +93,42 @@ class ConqDataRecorder:
 
         while not done.is_set():
             now = time.time()
-            state = clients.state.get_robot_state()
-            localization_state = clients.graphnav.get_localization_state()
+            state = None
+            localization_state = None
 
-            from conq.rerun_utils import viz_common_frames
-            viz_common_frames(state.kinematic_state.transforms_snapshot)
-
+            # Initialize step_data
             step_data = {
                 'time': now,
-                'robot_state': state,
-                'localization': localization_state.localization,
-                'is_lost': localization_state.lost_detector_state.is_lost,
+                'robot_state': None,
+                'localization': None,
+                'is_lost': None,
                 'instruction': self.latest_instruction,
                 'instruction_time': self.latest_instruction_time,
                 'images': {},
             }
 
-            reqs = []
-            for src, fmt in zip(self.sources, self.fmts):
-                req = build_image_request(src, pixel_format=fmt)
-                reqs.append(req)
+            # Check that the right cleint being requested is set before setting the step_data
+            if clients.state is not None:
+                state = clients.state.get_robot_state()
+                from conq.rerun_utils import viz_common_frames
+                viz_common_frames(state.kinematic_state.transforms_snapshot)
+                step_data['robot_state'] = state
 
-            ress = clients.image.get_image(reqs)
+            if clients.graphnav is not None:
+                localization_state = clients.graphnav.get_localization_state()
+                step_data['localization'] = localization_state.localization
+                step_data['is_lost'] = localization_state.lost_detector_state.is_lost
 
-            for res, src in zip(ress, self.sources):
-                step_data['images'][src] = res
+            if clients.image is not None:
+                reqs = []
+                for src, fmt in zip(self.sources, self.fmts):
+                    req = build_image_request(src, pixel_format=fmt)
+                    reqs.append(req)
+
+                ress = clients.image.get_image(reqs)
+
+                for res, src in zip(ress, self.sources):
+                    step_data['images'][src] = res
 
             # Get the action at the end, so we can see what the demonstrator was trying to do most recently.
             step_data['action'] = self.get_latest_action(now)

--- a/src/conq/data_recorder.py
+++ b/src/conq/data_recorder.py
@@ -64,10 +64,10 @@ class ConqDataRecorder:
         self.latest_instruction_time = time.time()
         self.episode_idx = 0
 
-    def start_episode(self, mode, instruction):
+    def start_episode(self, mode, instruction, save_interval: int = 50):
         self.episode_done = Event()
         self.saver_thread = Thread(target=self.save_episode_worker,
-                                   args=(self.clients, self.episode_done, mode))
+                                   args=(self.clients, self.episode_done, mode, save_interval))
         self.saver_thread.start()
         self.add_instruction(instruction)
 
@@ -84,7 +84,7 @@ class ConqDataRecorder:
         self.latest_instruction = text
         self.latest_instruction_time = time.time()
 
-    def save_episode_worker(self, clients, done: Event, mode: str, save_interval: int = 50):
+    def save_episode_worker(self, clients, done: Event, mode: str, save_interval):
         mode_path = self.root / mode
         mode_path.mkdir(exist_ok=True, parents=True)
 

--- a/src/conq/data_recorder.py
+++ b/src/conq/data_recorder.py
@@ -84,7 +84,7 @@ class ConqDataRecorder:
         self.latest_instruction = text
         self.latest_instruction_time = time.time()
 
-    def save_episode_worker(self, clients, done: Event, mode: str, save_interval):
+    def save_episode_worker(self, clients, done: Event, mode: str, episode_save_interval):
         mode_path = self.root / mode
         mode_path.mkdir(exist_ok=True, parents=True)
 
@@ -131,7 +131,7 @@ class ConqDataRecorder:
                     time.sleep(sleep_dt)
 
             # save
-            if len(episode) % save_interval == 0:
+            if len(episode) % episode_save_interval == 0:
                 with episode_path.open('wb') as f:
                     pickle.dump(episode, f)
 

--- a/src/conq/data_recorder.py
+++ b/src/conq/data_recorder.py
@@ -132,7 +132,8 @@ class ConqDataRecorder:
                     step_data['images'][src] = res
 
             # Get the action at the end, so we can see what the demonstrator was trying to do most recently.
-            step_data['action'] = self.get_latest_action(now)
+            if self.get_latest_action is not None:
+                step_data['action'] = self.get_latest_action(now)
 
             episode.append(step_data)
 

--- a/src/conq/data_recorder.py
+++ b/src/conq/data_recorder.py
@@ -101,9 +101,6 @@ class ConqDataRecorder:
             # Initialize step_data
             step_data = {
                 'time': now,
-                'robot_state': None,
-                'localization': None,
-                'is_lost': None,
                 'instruction': self.latest_instruction,
                 'instruction_time': self.latest_instruction_time,
                 'images': {},


### PR DESCRIPTION
- LocalizationState is now recorded within the `ConqDataRecorder` 
- `Clients` now includes the `GraphNavClient`
- Updated scripts that use the `ConqDataRecorder` since the recording function now uses a `Clients` object instead of passing them all individually