### PR TITLE
Added copying of map to the log file recorded

### DIFF
--- a/src/clickmap_nav/click_map_interface.py
+++ b/src/clickmap_nav/click_map_interface.py
@@ -27,7 +27,7 @@ class ClickMapInterface(GraphNavInterface, HighlightInteractorStyle):
         self.clients.state = self._robot_state_client
         now = int(time.time())
         root = Path(f"data/click_map_data_{now}")
-        self.recorder = ConqDataRecorder(root, self.clients, sources=ALL_SOURCES)
+        self.recorder = ConqDataRecorder(root, self.clients, sources=ALL_SOURCES, map_directory_path=upload_path)
         self.recorder_started = False
 
         self._list_graph_waypoint_and_edge_ids()

--- a/src/conq/data_recorder.py
+++ b/src/conq/data_recorder.py
@@ -3,20 +3,19 @@ import json
 import pickle
 import shutil
 import time
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 from multiprocessing import Event
 from pathlib import Path
 from threading import Thread
-from typing import Optional, Callable
+from typing import Callable, Optional
 
 import numpy as np
 from bosdyn.api.robot_state_pb2 import FootState
 from bosdyn.client.image import build_image_request
 
-from conq.cameras_utils import RGB_SOURCES, DEPTH_SOURCES, ALL_SOURCES, source_to_fmt
+from conq.cameras_utils import ALL_SOURCES, DEPTH_SOURCES, RGB_SOURCES, source_to_fmt
 from conq.clients import Clients
 from conq.rerun_utils import viz_common_frames
-
 
 
 class ConqDataRecorder:
@@ -161,14 +160,13 @@ class ConqDataRecorder:
     
     def copy_map_files(self, map_path: Path):
         if map_path.exists():
-            name = str(map_path).split('/')[-1]
             print(f"MAP PATH: {map_path}")
+            dst = self.root / map_path.name
             if map_path.is_dir():
-                shutil.copytree(map_path, f"{self.root}/{name}")
-                self.metadata['map_path'] = f"{self.root}/{name}"
+                shutil.copytree(map_path, dst)
             else:
-                shutil.copyfile(map_path, f"{self.root}/{name}")
-                self.metadata['map_path'] = f"{self.root}/{name}"
+                shutil.copyfile(map_path, dst)
+            self.metadata['map_path'] = dst.as_posix()
         else:
             print(f"WARNING from data_recorder.py: map path {map_path} does not exist! Not adding path to metadata.")
 


### PR DESCRIPTION
- Saves a copy of the map file in the data logging directory under the same name of the directory or walk file
- Adds the path of the map directory/file to the metadata

```json
{
  "bosdyn.api version": "3.3.2",
  "date": "2024-02-09T14:10:55.766229",
  "rgb_sources": [
    "hand_color_image",
    "back_fisheye_image",
    "frontleft_fisheye_image",
    "frontright_fisheye_image",
    "left_fisheye_image",
    "right_fisheye_image"
  ],
  "depth_sources": [
    "hand_depth",
    "frontleft_depth_in_visual_frame",
    "frontright_depth_in_visual_frame"
  ],
  "period": null,
  "map_path": "data/click_map_data_1707505855/downloaded_graph"
  ```