### PR TITLE
Implement API key storage via keyring

### DIFF
--- a/src/conq/api_keys/__init__.py
+++ b/src/conq/api_keys/__init__.py
@@ -1,0 +1,2 @@
+from .roboflow_api_key import ROBOFLOW_API_KEY
+from .replicate_api_key import REPLICATE_API_KEY

--- a/src/conq/api_keys/api_key_storage.py
+++ b/src/conq/api_keys/api_key_storage.py
@@ -1,0 +1,63 @@
+from typing import Optional
+from abc import ABC, abstractmethod
+import subprocess
+
+import keyring
+
+
+class ApiKeyStorage(ABC):
+    """Base class for convenient storage and retrieval of API keys
+
+    To use this class, create a subclass and implement the `__init__` method, calling this class's
+    `__init__` method with the service name and (optionally) the username.
+    """
+
+    @abstractmethod
+    def __init__(self, service: str, username: Optional[str] = None):
+        """Initializes the API key storage
+
+        Defaults to the current user's username if none is provided.
+        """
+        self.service: str = service
+        self.username: str = self._determine_username(username)
+        self._key: Optional[str] = None
+
+    def get(self) -> str:
+        """Returns the API key from the keyring
+
+        Prompts the user to input the API key if it is not already set
+        """
+        key = self._key
+        if key is None:
+            # Attempt to retrieve the key first as keys persist across sessions.
+            key = keyring.get_password(self.service, self.username)
+
+            # If the key is not found, prompt the user to input it.
+            if key is None:
+                self.set_via_user_input()
+                key = self.get()
+
+        return key
+
+    def delete(self):
+        keyring.delete_password(self.service, self.username)
+        self._key = None
+
+    def set_via_user_input(self):
+        """Prompts the user to set the API key"""
+        key = input(f"Please enter the API key for {self.service}: ")
+        self._set_key(key)
+
+    def _set_key(self, secret: str):
+        """Sets the API key in the keyring
+
+        NOTE: This should not be called directly! Use `set` instead.
+        """
+        keyring.set_password(self.service, self.username, secret)
+        self._key = secret
+
+    def _determine_username(self, username: Optional[str] = None):
+        """Sets the username for the API key"""
+        if username is None:
+            username = subprocess.check_output(["whoami"])
+        return username

--- a/src/conq/api_keys/api_key_storage.py
+++ b/src/conq/api_keys/api_key_storage.py
@@ -59,5 +59,5 @@ class ApiKeyStorage(ABC):
     def _determine_username(self, username: Optional[str] = None):
         """Sets the username for the API key"""
         if username is None:
-            username = subprocess.check_output(["whoami"])
+            username = subprocess.check_output(["whoami"]).decode("utf-8").strip()
         return username

--- a/src/conq/api_keys/replicate_api_key.py
+++ b/src/conq/api_keys/replicate_api_key.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from conq.api_keys.api_key_storage import ApiKeyStorage
+
+
+class ReplicateApiKey(ApiKeyStorage):
+
+    def __init__(self, username: Optional[str] = None):
+        super().__init__("replicate", username)
+
+
+REPLICATE_API_KEY = ReplicateApiKey()

--- a/src/conq/api_keys/roboflow_api_key.py
+++ b/src/conq/api_keys/roboflow_api_key.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from conq.api_keys.api_key_storage import ApiKeyStorage
+
+
+class RoboflowApiKey(ApiKeyStorage):
+
+    def __init__(self, username: Optional[str] = None):
+        super().__init__("roboflow", username)
+
+
+ROBOFLOW_API_KEY = RoboflowApiKey()

--- a/src/conq/perception_lib/fetch_roboflow_data.py
+++ b/src/conq/perception_lib/fetch_roboflow_data.py
@@ -14,8 +14,10 @@ Python:
 
 from roboflow import Roboflow
 
+from conq.api_keys import ROBOFLOW_API_KEY
+
 # Config stuff
-rf = Roboflow(api_key="***ADD API KEY HERE***")
+rf = Roboflow(api_key=ROBOFLOW_API_KEY.get())
 
 project = rf.workspace("agrobots-9sm1u").project("garden-implements")
 dataset = project.version(5).download("yolov8")

--- a/src/conq/perception_lib/run_roboflow_inference.py
+++ b/src/conq/perception_lib/run_roboflow_inference.py
@@ -2,8 +2,11 @@
 
 from roboflow import Roboflow
 
+from conq.api_keys import ROBOFLOW_API_KEY
+
 # Config stuff
-rf = Roboflow(api_key="***ADD API KEY HERE***")
+rf = Roboflow(api_key=ROBOFLOW_API_KEY.get())
+
 
 def run_roboflow_model_inference():
     project = rf.workspace().project("garden-implements")
@@ -13,4 +16,3 @@ def run_roboflow_model_inference():
     # print(model.predict("URL_OF_YOUR_IMAGE").json())
 
     model.predict("your_image.jpg").save("prediction.jpg")
-

--- a/src/conq/perception_lib/sam_inference.py
+++ b/src/conq/perception_lib/sam_inference.py
@@ -1,11 +1,6 @@
-"""Replicate API Token for AgroBots: "***ADD API KEY HERE***"
-
-Terminal -> Run below command
-$ export REPLICATE_API_TOKEN="***ADD API TOKEN HERE***"
-
+"""
 To run this script:
 $ python3 sam_inference.py --input-image https://your_image_url.jpg
-
 """
 
 import os
@@ -17,7 +12,10 @@ import cv2
 import numpy as np
 import replicate
 
-os.environ['REPLICATE_API_TOKEN'] = '***ADD API TOKEN HERE***'
+from conq.api_keys import REPLICATE_API_KEY
+
+os.environ['REPLICATE_API_TOKEN'] = REPLICATE_API_KEY.get()
+
 
 def run_sam_inference(image_url):
     start_time = time.time()


### PR DESCRIPTION
- Implements a really simple API key storage solution so that no keys are committed on accident. This uses python bindings to GNOME keyring which is a pretty standard method of storing secrets.
- Opted to use keyring instead of environment or configuration files as keyring supports encryption.
- Due to this, we could also store robot credentials using keyring, preventing us from having to specify usernames/passwords or hard-code them. This is on my TODO list.