### PR TITLE
Openai vision example

### DIFF
--- a/src/conq/navigation_lib/openai_nav/openai_nav_client.py
+++ b/src/conq/navigation_lib/openai_nav/openai_nav_client.py
@@ -95,7 +95,7 @@ class OpenAINavClient:
     @limits(calls=3, period=ONE_MINUTE)
     def generate_label_for_image(self, prompt="Using only one to two words to answer with no reasoning, please classify what you see in this image into a specific label that is intuitive for humans trying to understand what the tools here are used for relative to gardening and farming", image_url="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT354l_oPc87wCqcXwlLKCRPLfZUP-Cs3Wbzw&usqp=CAU"):
         response = self.llm_client.chat.completions.create(
-            model="gpt-4-turbo",
+            model=os.environ["model"],
             messages=[
                 {
                 "role": "user",
@@ -113,4 +113,4 @@ class OpenAINavClient:
             temperature=0,
         )
     
-        print(f"The picture is described as: {response.choices[0].message.content}")
+        print(response.choices[0].message.content)

--- a/src/conq/navigation_lib/openai_nav/openai_nav_client.py
+++ b/src/conq/navigation_lib/openai_nav/openai_nav_client.py
@@ -93,7 +93,7 @@ class OpenAINavClient:
         return probabilities_out
 
     @limits(calls=3, period=ONE_MINUTE)
-    def generate_label_for_image(self, prompt="Using only one to two words to answer with no reasoning, please classify what you see in this image into a specific label that is intuitive for humans trying to understand what the tools here are used for relative to gardening and farming", image_url="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT354l_oPc87wCqcXwlLKCRPLfZUP-Cs3Wbzw&usqp=CAU"):
+    def generate_label_for_image(self, prompt="Please describe the primary function of the following group of tools in a concise manner using no more than five words and avoid general terms like \"essential\" or \"gardening\".", image_url="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT354l_oPc87wCqcXwlLKCRPLfZUP-Cs3Wbzw&usqp=CAU"):
         response = self.llm_client.chat.completions.create(
             model=os.environ["model"],
             messages=[

--- a/src/conq/navigation_lib/openai_nav/openai_nav_client.py
+++ b/src/conq/navigation_lib/openai_nav/openai_nav_client.py
@@ -91,3 +91,26 @@ class OpenAINavClient:
                 )
 
         return probabilities_out
+
+    @limits(calls=3, period=ONE_MINUTE)
+    def generate_label_for_image(self, prompt="Using only one to two words to answer with no reasoning, please classify what you see in this image into a specific label that is intuitive for humans trying to understand what the tools here are used for relative to gardening and farming", image_url="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT354l_oPc87wCqcXwlLKCRPLfZUP-Cs3Wbzw&usqp=CAU"):
+        response = self.llm_client.chat.completions.create(
+            model="gpt-4-turbo",
+            messages=[
+                {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": image_url,
+                    },
+                    },
+                ],
+                }
+            ],
+            temperature=0,
+        )
+    
+        print(f"The picture is described as: {response.choices[0].message.content}")

--- a/src/conq/navigation_lib/openai_nav_example/README.md
+++ b/src/conq/navigation_lib/openai_nav_example/README.md
@@ -5,3 +5,16 @@ This script is an emaple of how to use the OpenAI Client in Python and to go fro
 ```bash
 python3 openai_nav_example.py
 ```
+
+# OpenAI Vision Example
+
+### **NOTE:** This example is a work in progress and serves primarily as an example/playground for the ChatGPT vision service.
+
+This script allows users to test out providing prompts to ChatGPT to use it to describe what is in an image. Currently, links to two images of various garden tools are passed to ChatGPT with the user prompt. To use different images, either download images or use a different link. More information on using images with ChatGPT can be found on the [OpenAI Documentation](https://platform.openai.com/docs/guides/vision) page.
+
+To run the script, run:
+```bash
+python3 openai_vision_example.py
+```
+
+When prompted, enter your prompt and see the results in real time. If you would like to quit, type in `q` for the user prompt.

--- a/src/conq/navigation_lib/openai_nav_example/README.md
+++ b/src/conq/navigation_lib/openai_nav_example/README.md
@@ -10,7 +10,7 @@ python3 openai_nav_example.py
 
 ### **NOTE:** This example is a work in progress and serves primarily as an example/playground for the ChatGPT vision service.
 
-This script allows users to test out providing prompts to ChatGPT to use it to describe what is in an image. Currently, links to two images of various garden tools are passed to ChatGPT with the user prompt in [`example_input.json`](./example_input.json). To use different images, add or remove links under the `image_inputs` key. More information on using images with ChatGPT can be found on the [OpenAI Documentation](https://platform.openai.com/docs/guides/vision) page.
+This script allows users to test out providing prompts to ChatGPT to use it to describe what is in an image. Currently, links to two images of various garden tools are passed to ChatGPT with the user prompt in [`example_input.json`](./example_input.json). To try different prompts, either enter a prompt into the input or set the `user_prompt` in the JSON file. To use different images, add or remove links under the `image_inputs` key. More information on using images with ChatGPT can be found on the [OpenAI Documentation](https://platform.openai.com/docs/guides/vision) page.
 
 To run the script, run:
 ```bash

--- a/src/conq/navigation_lib/openai_nav_example/README.md
+++ b/src/conq/navigation_lib/openai_nav_example/README.md
@@ -10,11 +10,16 @@ python3 openai_nav_example.py
 
 ### **NOTE:** This example is a work in progress and serves primarily as an example/playground for the ChatGPT vision service.
 
-This script allows users to test out providing prompts to ChatGPT to use it to describe what is in an image. Currently, links to two images of various garden tools are passed to ChatGPT with the user prompt. To use different images, either download images or use a different link. More information on using images with ChatGPT can be found on the [OpenAI Documentation](https://platform.openai.com/docs/guides/vision) page.
+This script allows users to test out providing prompts to ChatGPT to use it to describe what is in an image. Currently, links to two images of various garden tools are passed to ChatGPT with the user prompt in [`example_input.json`](./example_input.json). To use different images, add or remove links under the `image_inputs` key. More information on using images with ChatGPT can be found on the [OpenAI Documentation](https://platform.openai.com/docs/guides/vision) page.
 
 To run the script, run:
 ```bash
-python3 openai_vision_example.py
+python3 --json-filepath example_input.json openai_vision_example.py
 ```
 
-When prompted, enter your prompt and see the results in real time. If you would like to quit, type in `q` for the user prompt.
+### Prompts
+When prompted, enter your prompt and see the results in real time.
+
+* `q`: quit the program
+* `j`: use the user prompt in the JSON file provided
+* Any other input will be interpreted as the prompt to ChatGPT

--- a/src/conq/navigation_lib/openai_nav_example/README.md
+++ b/src/conq/navigation_lib/openai_nav_example/README.md
@@ -14,7 +14,7 @@ This script allows users to test out providing prompts to ChatGPT to use it to d
 
 To run the script, run:
 ```bash
-python3 --json-filepath example_input.json openai_vision_example.py
+python3 openai_vision_example.py --json-filepath example_input.json
 ```
 
 ### Prompts

--- a/src/conq/navigation_lib/openai_nav_example/example_input.json
+++ b/src/conq/navigation_lib/openai_nav_example/example_input.json
@@ -1,7 +1,8 @@
 {
-    "user_prompt": "You are given a picture of various tools. Your task is to group these tools and assign a one to two-word label that captures what they are specifically used for. Please provide the label for each group of tools.",
+    "user_prompt": "Please describe the primary function of the following group of tools in a concise manner using no more than five words and avoid general terms like \"essential\" or \"gardening\".",
     "image_inputs": [
         "https://www.fromhousetohome.com/garden/wp-content/uploads/sites/2/2022/05/garden-tool-storage-ideas-3.jpg",
-        "https://www.fromhousetohome.com/garden/wp-content/uploads/sites/2/2022/05/garden-tool-storage-ideas-3.jpg"
+        "https://www.marthastewart.com/thmb/0ysf_-1O-u1IDLg9QpLtsTCsZsU=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/gardening-tools-getty-0621-2000-1e1dec199e8148299f1294b9fe6971ab.jpg",
+        "https://ucanr.edu/blogs/dirt/blogfiles/101636_original.jpg"
     ]
 }

--- a/src/conq/navigation_lib/openai_nav_example/example_input.json
+++ b/src/conq/navigation_lib/openai_nav_example/example_input.json
@@ -1,0 +1,7 @@
+{
+    "user_prompt": "You are given a picture of various tools. Your task is to group these tools and assign a one to two-word label that captures what they are specifically used for. Please provide the label for each group of tools.",
+    "image_inputs": [
+        "https://www.fromhousetohome.com/garden/wp-content/uploads/sites/2/2022/05/garden-tool-storage-ideas-3.jpg",
+        "https://www.fromhousetohome.com/garden/wp-content/uploads/sites/2/2022/05/garden-tool-storage-ideas-3.jpg"
+    ]
+}

--- a/src/conq/navigation_lib/openai_nav_example/openai_vision_example.py
+++ b/src/conq/navigation_lib/openai_nav_example/openai_vision_example.py
@@ -1,15 +1,38 @@
+import argparse
+import json
+import sys
+
 from conq.navigation_lib.openai_nav.openai_nav_client import OpenAINavClient
 
-if __name__ == "__main__":
+# Main function with argument parsing that takes in a relative path to a JSON file and then saves the prompt and image URL array into variables
+# Then, it creates an OpenAINavClient object and calls the generate_label_for_image function with the prompt and image URL
+
+def main(argv):
+    parser = argparse.ArgumentParser(description='OpenAI Vision API Example')
+    parser.add_argument('--json-filepath', type=str, help='Relative path to JSON file with prompt and image URL', required=True)
+    args = parser.parse_args(argv)
+
+    with open(args.json_filepath, 'r') as file:
+        data = file.read()
+
+    data = json.loads(data)
+    prompt = data['user_prompt']
+    image_urls = data['image_inputs']
+
     client = OpenAINavClient(locations=[])
 
-    # Creating while loop to debug with
     while True:
-        user_prompt = input("Enter prompt, (q) to quit: ")
+        user_prompt = input("Enter prompt, (j) for input in JSON file, (q) to quit, or another string to be used as the prompt: ")
         if user_prompt == "q":
             break
+        elif user_prompt == "j":
+            for image_url in image_urls:
+                print(f"Processing Image URL: {image_url}")
+                client.generate_label_for_image(prompt=prompt, image_url=image_url)
         else:
-            print("First image processing...")
-            client.generate_label_for_image(prompt=user_prompt, image_url="https://www.fromhousetohome.com/garden/wp-content/uploads/sites/2/2022/05/garden-tool-storage-ideas-3.jpg")
-            print("Second image processing...")
-            client.generate_label_for_image(prompt=user_prompt, image_url="https://img.hobbyfarms.com/wp-content/uploads/2009/02/18104206/harvest-tools_624.jpg")
+            for image_url in image_urls:
+                print(f"Processing Image URL: {image_url}")
+                client.generate_label_for_image(prompt=user_prompt, image_url=image_url)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/conq/navigation_lib/openai_nav_example/openai_vision_example.py
+++ b/src/conq/navigation_lib/openai_nav_example/openai_vision_example.py
@@ -1,0 +1,15 @@
+from conq.navigation_lib.openai_nav.openai_nav_client import OpenAINavClient
+
+if __name__ == "__main__":
+    client = OpenAINavClient(locations=[])
+
+    # Creating while loop to debug with
+    while True:
+        user_prompt = input("Enter prompt, (q) to quit: ")
+        if user_prompt == "q":
+            break
+        else:
+            print("First image processing...")
+            client.generate_label_for_image(prompt=user_prompt, image_url="https://www.fromhousetohome.com/garden/wp-content/uploads/sites/2/2022/05/garden-tool-storage-ideas-3.jpg")
+            print("Second image processing...")
+            client.generate_label_for_image(prompt=user_prompt, image_url="https://img.hobbyfarms.com/wp-content/uploads/2009/02/18104206/harvest-tools_624.jpg")


### PR DESCRIPTION
Added a function to pass an image to OpenAI ChatGPT to process it and return a label based on the default prompt or one provided by the user. Also added an example for using the new function and with supporting documentation.